### PR TITLE
feat: Phase 3 — integration tests, date pattern tests, smoke tests, LangSmith evaluators

### DIFF
--- a/agent/graph/nodes/date_parser.py
+++ b/agent/graph/nodes/date_parser.py
@@ -217,13 +217,17 @@ def _parse_simple_range(message: str) -> tuple[str, str, str] | None:
                 f"{m.group(1)} days ago",
             ),
         ),
-        # "Q1 2024" / "Q3 of 2022" — absolute calendar quarters
-        # Must come after relative patterns so "last quarter" doesn't conflict.
-        (
+    ]
+
+    # "Q1 2024" / "Q3 of 2022" — absolute calendar quarters.
+    # Only added when "earnings" is NOT in the message so that earnings-relative
+    # queries (e.g. "around Q2 2024 earnings") fall through to Layer 2 instead
+    # of resolving as a full calendar quarter here.
+    if "earnings" not in message.lower():
+        patterns.append((
             re.compile(r"\bQ([1-4])\s+(?:of\s+)?(\d{4})\b", re.IGNORECASE),
             lambda m: _quarter_range(int(m.group(1)), int(m.group(2))),
-        ),
-    ]
+        ))
 
     for pattern, handler in patterns:
         match = pattern.search(message)

--- a/agent/graph/nodes/date_parser.py
+++ b/agent/graph/nodes/date_parser.py
@@ -89,6 +89,17 @@ If no date range can be determined, respond:
 # Layer 1: simple relative range patterns
 # ---------------------------------------------------------------------------
 
+def _quarter_range(quarter: int, year: int) -> tuple[str, str, str]:
+    """Return (start_iso, end_iso, context) for a calendar quarter."""
+    import calendar
+    month_start = (quarter - 1) * 3 + 1
+    month_end = quarter * 3
+    _, last_day = calendar.monthrange(year, month_end)
+    start = f"{year}-{month_start:02d}-01"
+    end = f"{year}-{month_end:02d}-{last_day:02d}"
+    return start, end, f"Q{quarter} {year}"
+
+
 def _parse_simple_range(message: str) -> tuple[str, str, str] | None:
     """
     Match common relative date expressions via regex.
@@ -205,6 +216,12 @@ def _parse_simple_range(message: str) -> tuple[str, str, str] | None:
                 today,
                 f"{m.group(1)} days ago",
             ),
+        ),
+        # "Q1 2024" / "Q3 of 2022" — absolute calendar quarters
+        # Must come after relative patterns so "last quarter" doesn't conflict.
+        (
+            re.compile(r"\bQ([1-4])\s+(?:of\s+)?(\d{4})\b", re.IGNORECASE),
+            lambda m: _quarter_range(int(m.group(1)), int(m.group(2))),
         ),
     ]
 

--- a/agent/graph/nodes/response_synthesizer.py
+++ b/agent/graph/nodes/response_synthesizer.py
@@ -383,6 +383,7 @@ def synthesize_response(state: AgentState) -> AgentState:
             **state,
             "response_text": response_text,
             "sources_cited": sources_cited,
+            "synthesizer_context": prompt,
             "synthesizer_error": None,
         }
 

--- a/agent/graph/nodes/state.py
+++ b/agent/graph/nodes/state.py
@@ -276,6 +276,12 @@ class AgentState(TypedDict, total=False):
     # clickable links below the narrative, not buried inside it.
     # Read by: Chainlit app.py.
 
+    synthesizer_context: Optional[str]
+    # The assembled data prompt that was sent to the LLM (price, news, filings, etc.)
+    # Saved so LangSmith hallucination evaluators can check response_text against
+    # the actual facts the model had access to.
+    # Not displayed in the UI.
+
     # -------------------------------------------------------------------------
     # Node 10: Chart Generator
     # Reads: ticker, price_data (specifically daily_prices)

--- a/docs/langsmith-setup.md
+++ b/docs/langsmith-setup.md
@@ -1,0 +1,60 @@
+# LangSmith Setup Guide
+
+One-time setup steps per project. These are UI actions that cannot be automated.
+
+## Project Setup
+
+1. Go to LangSmith → Projects → `stock-insight-agent`
+2. Confirm `LANGCHAIN_TRACING_V2=true` and `LANGCHAIN_PROJECT=stock-insight-agent` are set in `.env`
+
+## Custom Evaluators (one-time per evaluator)
+
+For each evaluator in `tests/evaluators/custom_evaluators.py`:
+
+1. LangSmith → Experiments → Evaluators → **+ New Evaluator**
+2. Name: (use the key from the function, e.g. `date_range_accuracy`)
+3. Type: **Python Code**
+4. Paste the function body from `tests/evaluators/custom_evaluators.py`
+5. Save
+
+Evaluators to create (6 total):
+- `date_range_accuracy`
+- `chart_generated_when_requested`
+- `rag_chunks_retrieved`
+- `response_depth_respected`
+- `intent_accuracy`
+- `source_attribution`
+
+## Prebuilt Evaluators (2 clicks each)
+
+1. LangSmith → Projects → `stock-insight-agent` → Online Evaluation → **+ Add Evaluator**
+2. Select **Hallucination** (LLM as judge) → Enable
+3. Select **Conciseness** (LLM as judge) → Enable
+
+## Dataset: Add 5 New Examples
+
+Go to LangSmith → Datasets → `stock-insight-agent-evals` (or create it).
+
+Add these 5 examples:
+
+| Input query | Expected outputs |
+|-------------|-----------------|
+| "Tell me how Nvidia did Q4 2025" | `{"intent": "stock_analysis", "start_date": "2025-10-01", "end_date": "2025-12-31"}` |
+| "How did TSLA do Q1 2024?" | `{"intent": "stock_analysis", "start_date": "2024-01-01", "end_date": "2024-03-31"}` |
+| "Deep dive on NVDA last month" | `{"intent": "stock_analysis", "response_depth": "deep"}` |
+| "What happened with Apple around Q2 2024 earnings?" | `{"intent": "stock_analysis"}` |
+| "What about the chart?" (follow-up — test session context) | `{"intent": "chart_request", "chart_requested": true}` |
+
+## Running an Experiment
+
+After setup, run the `baseline-post-review` experiment:
+
+```
+From the LangSmith UI: Experiments → Run Experiment
+Dataset: stock-insight-agent-evals
+Project: stock-insight-agent
+Name: baseline-post-review
+Evaluators: select all 6 custom + Hallucination + Conciseness
+```
+
+Compare `baseline-post-review` against `baseline-4d729529` to produce before/after quality report.

--- a/docs/langsmith-setup.md
+++ b/docs/langsmith-setup.md
@@ -7,14 +7,28 @@ One-time setup steps per project. These are UI actions that cannot be automated.
 1. Go to LangSmith → Projects → `stock-insight-agent`
 2. Confirm `LANGCHAIN_TRACING_V2=true` and `LANGCHAIN_PROJECT=stock-insight-agent` are set in `.env`
 
-## Custom Evaluators (one-time per evaluator)
+## Running Experiments (fully automated)
 
-For each evaluator in `tests/evaluators/custom_evaluators.py`:
+The preferred approach — no UI setup required:
+
+```bash
+source .venv/bin/activate
+PYTHONPATH=. python tests/evaluators/run_experiment.py
+```
+
+This runs all 6 evaluators against the dataset and uploads results to LangSmith
+under the experiment name `baseline-post-review`. View results at smith.langchain.com.
+
+## Custom Evaluators (UI approach — optional)
+
+If you want to save evaluators for reuse from the LangSmith UI:
 
 1. LangSmith → Experiments → Evaluators → **+ New Evaluator**
 2. Name: (use the key from the function, e.g. `date_range_accuracy`)
 3. Type: **Python Code**
-4. Paste the function body from `tests/evaluators/custom_evaluators.py`
+4. Adapt the function from `tests/evaluators/custom_evaluators.py` to use
+   the UI signature: `def fn(run, example)` where `run.outputs` and `example.outputs`
+   replace the `outputs` and `reference_outputs` parameters
 5. Save
 
 Evaluators to create (6 total):

--- a/tests/evaluators/custom_evaluators.py
+++ b/tests/evaluators/custom_evaluators.py
@@ -152,6 +152,59 @@ def source_attribution(outputs: dict, reference_outputs: dict) -> dict:
     }
 
 
+def hallucination(outputs: dict, reference_outputs: dict) -> dict:
+    """
+    LLM-as-judge: checks whether response_text makes claims not supported
+    by synthesizer_context (the actual data the model was given).
+
+    Score: 1.0 = no hallucination detected, 0.0 = hallucination detected.
+    Returns None if synthesizer_context or response_text is missing.
+    """
+    import json
+    from langchain_groq import ChatGroq
+    from langchain_core.messages import HumanMessage
+
+    response_text = outputs.get("response_text")
+    context = outputs.get("synthesizer_context")
+
+    if not response_text or not context:
+        return {"key": "hallucination", "score": None, "comment": "Missing response_text or synthesizer_context"}
+
+    judge = ChatGroq(model="llama-3.1-8b-instant", temperature=0, max_tokens=256)
+
+    prompt = f"""You are evaluating whether an AI response hallucinates facts not present in the source data.
+
+<source_data>
+{context[:3000]}
+</source_data>
+
+<response>
+{response_text[:2000]}
+</response>
+
+Does the response make any specific factual claims (numbers, dates, events, quotes) that are NOT supported by the source data above?
+
+Reply with JSON only: {{"hallucination": true/false, "reason": "one sentence"}}"""
+
+    try:
+        result = judge.invoke([HumanMessage(content=prompt)])
+        raw = result.content.strip()
+        if raw.startswith("```"):
+            raw = raw.split("```")[1]
+            if raw.lower().startswith("json"):
+                raw = raw[4:]
+            raw = raw.strip()
+        parsed = json.loads(raw)
+        detected = parsed.get("hallucination", False)
+        return {
+            "key": "hallucination",
+            "score": 0.0 if detected else 1.0,
+            "comment": parsed.get("reason", ""),
+        }
+    except Exception as e:
+        return {"key": "hallucination", "score": None, "comment": f"Judge failed: {e}"}
+
+
 ALL_EVALUATORS = [
     date_range_accuracy,
     chart_generated_when_requested,
@@ -159,4 +212,5 @@ ALL_EVALUATORS = [
     response_depth_respected,
     intent_accuracy,
     source_attribution,
+    hallucination,
 ]

--- a/tests/evaluators/custom_evaluators.py
+++ b/tests/evaluators/custom_evaluators.py
@@ -1,32 +1,32 @@
 """
 LangSmith custom evaluators for the Stock Insight Agent.
 
-These functions are used as custom code evaluators in LangSmith experiments.
-To use: copy each function into a LangSmith evaluator via the UI
-(Experiments → Evaluators → + New Evaluator → Python Code).
+Two usage modes:
 
-Each function signature: evaluate(run, example) -> dict
-  run:     the LangSmith run object (contains inputs and outputs)
-  example: the dataset example (contains reference outputs)
-  return:  {"key": "evaluator_name", "score": 0.0–1.0}
+1. SDK / run_experiment.py (signature: outputs, reference_outputs):
+   Used by client.evaluate() in run_experiment.py. Each function receives the
+   graph's output dict and the dataset example's expected outputs.
+
+2. LangSmith UI (signature: run, example):
+   If you want to save an evaluator in the LangSmith UI (Experiments → Evaluators
+   → + New Evaluator → Python Code), see docs/langsmith-setup.md for the UI
+   variant of each function. The logic is identical; only the signature differs.
 """
 
 
-def date_range_accuracy(run, example) -> dict:
-    """
-    Assert start_date and end_date match the quarter/period in the query.
-    Score: 1.0 if both dates match expected, 0.0 otherwise.
+# ---------------------------------------------------------------------------
+# SDK evaluators  (outputs: dict, reference_outputs: dict) -> dict
+# ---------------------------------------------------------------------------
 
-    Expected outputs in dataset example:
-      {"start_date": "YYYY-MM-DD", "end_date": "YYYY-MM-DD"}
+def date_range_accuracy(outputs: dict, reference_outputs: dict) -> dict:
     """
-    outputs = run.outputs or {}
-    reference = example.outputs or {}
-
+    Assert start_date and end_date match the expected values in the dataset example.
+    Score: 1.0 if both match, 0.0 otherwise. None if no reference dates provided.
+    """
     actual_start = outputs.get("start_date", "")
     actual_end = outputs.get("end_date", "")
-    expected_start = reference.get("start_date", "")
-    expected_end = reference.get("end_date", "")
+    expected_start = reference_outputs.get("start_date", "")
+    expected_end = reference_outputs.get("end_date", "")
 
     if not expected_start or not expected_end:
         return {"key": "date_range_accuracy", "score": None, "comment": "No reference dates in example"}
@@ -39,13 +39,12 @@ def date_range_accuracy(run, example) -> dict:
     }
 
 
-def chart_generated_when_requested(run, example) -> dict:
+def chart_generated_when_requested(outputs: dict, reference_outputs: dict) -> dict:
     """
     If chart_requested=True in output, assert chart_data is non-null.
-    Score: 1.0 if chart_requested=False (nothing to check) or chart_data is present.
-            0.0 if chart_requested=True but chart_data is None.
+    Score: 1.0 if chart was not requested, or if chart_data is present.
+            0.0 if chart was requested but chart_data is None.
     """
-    outputs = run.outputs or {}
     chart_requested = outputs.get("chart_requested", False)
     chart_data = outputs.get("chart_data")
 
@@ -60,14 +59,12 @@ def chart_generated_when_requested(run, example) -> dict:
     }
 
 
-def rag_chunks_retrieved(run, example) -> dict:
+def rag_chunks_retrieved(outputs: dict, reference_outputs: dict) -> dict:
     """
-    If intent includes filings (stock_analysis or general_lookup),
-    assert len(filing_chunks) > 0.
+    If intent is stock_analysis or general_lookup, assert filing_chunks is non-empty.
     Score: 1.0 if chunks present or intent does not require filings.
             0.0 if intent requires filings and chunks is empty.
     """
-    outputs = run.outputs or {}
     intent = outputs.get("intent", "")
     filing_chunks = outputs.get("filing_chunks") or []
 
@@ -82,17 +79,15 @@ def rag_chunks_retrieved(run, example) -> dict:
     }
 
 
-def response_depth_respected(run, example) -> dict:
+def response_depth_respected(outputs: dict, reference_outputs: dict) -> dict:
     """
     If response_depth=deep, assert all 5 markdown sections are present in response_text.
-    Score: 1.0 if depth=quick (no sections required) or all 5 sections present.
-            0.0 if depth=deep and any section is missing.
+    Score: 1.0 if depth=quick or all 5 sections present. 0.0 if any section missing.
 
     Section names match the response_synthesizer deep prompt:
       ## Price Action, ## News & Catalysts, ## Market Sentiment,
       ## SEC Filings, ## Options Activity
     """
-    outputs = run.outputs or {}
     response_depth = outputs.get("response_depth", "quick")
     response_text = outputs.get("response_text") or ""
 
@@ -115,19 +110,13 @@ def response_depth_respected(run, example) -> dict:
     }
 
 
-def intent_accuracy(run, example) -> dict:
+def intent_accuracy(outputs: dict, reference_outputs: dict) -> dict:
     """
-    Assert output intent matches expected_intent in dataset example.
-    Score: 1.0 if match, 0.0 otherwise.
-
-    Expected outputs in dataset example:
-      {"intent": "stock_analysis"}  (or whichever intent is expected)
+    Assert output intent matches the expected intent in the dataset example.
+    Score: 1.0 if match, 0.0 otherwise. None if no reference intent provided.
     """
-    outputs = run.outputs or {}
-    reference = example.outputs or {}
-
     actual = outputs.get("intent", "")
-    expected = reference.get("intent", "")
+    expected = reference_outputs.get("intent", "")
 
     if not expected:
         return {"key": "intent_accuracy", "score": None, "comment": "No reference intent in example"}
@@ -140,13 +129,12 @@ def intent_accuracy(run, example) -> dict:
     }
 
 
-def source_attribution(run, example) -> dict:
+def source_attribution(outputs: dict, reference_outputs: dict) -> dict:
     """
-    Assert len(sources_cited) > 0 when news_articles or filing_chunks are non-empty.
-    Score: 1.0 if sources_cited is populated when data is available, or if no data available.
+    Assert sources_cited is non-empty when news_articles or filing_chunks are available.
+    Score: 1.0 if sources cited when data available, or no data available.
             0.0 if data was available but no sources were cited.
     """
-    outputs = run.outputs or {}
     news_articles = outputs.get("news_articles") or []
     filing_chunks = outputs.get("filing_chunks") or []
     sources_cited = outputs.get("sources_cited") or []
@@ -162,3 +150,13 @@ def source_attribution(run, example) -> dict:
         "score": score,
         "comment": f"{len(sources_cited)} sources cited, {len(news_articles)} news + {len(filing_chunks)} filing chunks available",
     }
+
+
+ALL_EVALUATORS = [
+    date_range_accuracy,
+    chart_generated_when_requested,
+    rag_chunks_retrieved,
+    response_depth_respected,
+    intent_accuracy,
+    source_attribution,
+]

--- a/tests/evaluators/custom_evaluators.py
+++ b/tests/evaluators/custom_evaluators.py
@@ -1,0 +1,164 @@
+"""
+LangSmith custom evaluators for the Stock Insight Agent.
+
+These functions are used as custom code evaluators in LangSmith experiments.
+To use: copy each function into a LangSmith evaluator via the UI
+(Experiments → Evaluators → + New Evaluator → Python Code).
+
+Each function signature: evaluate(run, example) -> dict
+  run:     the LangSmith run object (contains inputs and outputs)
+  example: the dataset example (contains reference outputs)
+  return:  {"key": "evaluator_name", "score": 0.0–1.0}
+"""
+
+
+def date_range_accuracy(run, example) -> dict:
+    """
+    Assert start_date and end_date match the quarter/period in the query.
+    Score: 1.0 if both dates match expected, 0.0 otherwise.
+
+    Expected outputs in dataset example:
+      {"start_date": "YYYY-MM-DD", "end_date": "YYYY-MM-DD"}
+    """
+    outputs = run.outputs or {}
+    reference = example.outputs or {}
+
+    actual_start = outputs.get("start_date", "")
+    actual_end = outputs.get("end_date", "")
+    expected_start = reference.get("start_date", "")
+    expected_end = reference.get("end_date", "")
+
+    if not expected_start or not expected_end:
+        return {"key": "date_range_accuracy", "score": None, "comment": "No reference dates in example"}
+
+    match = (actual_start == expected_start) and (actual_end == expected_end)
+    return {
+        "key": "date_range_accuracy",
+        "score": 1.0 if match else 0.0,
+        "comment": f"actual=[{actual_start} → {actual_end}] expected=[{expected_start} → {expected_end}]",
+    }
+
+
+def chart_generated_when_requested(run, example) -> dict:
+    """
+    If chart_requested=True in output, assert chart_data is non-null.
+    Score: 1.0 if chart_requested=False (nothing to check) or chart_data is present.
+            0.0 if chart_requested=True but chart_data is None.
+    """
+    outputs = run.outputs or {}
+    chart_requested = outputs.get("chart_requested", False)
+    chart_data = outputs.get("chart_data")
+
+    if not chart_requested:
+        return {"key": "chart_generated_when_requested", "score": 1.0, "comment": "Chart not requested — N/A"}
+
+    score = 1.0 if chart_data else 0.0
+    return {
+        "key": "chart_generated_when_requested",
+        "score": score,
+        "comment": "chart_data present" if chart_data else "chart_requested=True but chart_data is None",
+    }
+
+
+def rag_chunks_retrieved(run, example) -> dict:
+    """
+    If intent includes filings (stock_analysis or general_lookup),
+    assert len(filing_chunks) > 0.
+    Score: 1.0 if chunks present or intent does not require filings.
+            0.0 if intent requires filings and chunks is empty.
+    """
+    outputs = run.outputs or {}
+    intent = outputs.get("intent", "")
+    filing_chunks = outputs.get("filing_chunks") or []
+
+    if intent not in ("stock_analysis", "general_lookup"):
+        return {"key": "rag_chunks_retrieved", "score": 1.0, "comment": f"Intent={intent} — RAG not required"}
+
+    score = 1.0 if len(filing_chunks) > 0 else 0.0
+    return {
+        "key": "rag_chunks_retrieved",
+        "score": score,
+        "comment": f"{len(filing_chunks)} chunks retrieved",
+    }
+
+
+def response_depth_respected(run, example) -> dict:
+    """
+    If response_depth=deep, assert all 5 markdown sections are present in response_text.
+    Score: 1.0 if depth=quick (no sections required) or all 5 sections present.
+            0.0 if depth=deep and any section is missing.
+
+    Section names match the response_synthesizer deep prompt:
+      ## Price Action, ## News & Catalysts, ## Market Sentiment,
+      ## SEC Filings, ## Options Activity
+    """
+    outputs = run.outputs or {}
+    response_depth = outputs.get("response_depth", "quick")
+    response_text = outputs.get("response_text") or ""
+
+    if response_depth != "deep":
+        return {"key": "response_depth_respected", "score": 1.0, "comment": "Quick mode — sections not required"}
+
+    required_sections = [
+        "## Price Action",
+        "## News & Catalysts",
+        "## Market Sentiment",
+        "## SEC Filings",
+        "## Options Activity",
+    ]
+    missing = [s for s in required_sections if s not in response_text]
+    score = 1.0 if not missing else 0.0
+    return {
+        "key": "response_depth_respected",
+        "score": score,
+        "comment": f"Missing sections: {missing}" if missing else "All 5 sections present",
+    }
+
+
+def intent_accuracy(run, example) -> dict:
+    """
+    Assert output intent matches expected_intent in dataset example.
+    Score: 1.0 if match, 0.0 otherwise.
+
+    Expected outputs in dataset example:
+      {"intent": "stock_analysis"}  (or whichever intent is expected)
+    """
+    outputs = run.outputs or {}
+    reference = example.outputs or {}
+
+    actual = outputs.get("intent", "")
+    expected = reference.get("intent", "")
+
+    if not expected:
+        return {"key": "intent_accuracy", "score": None, "comment": "No reference intent in example"}
+
+    match = actual == expected
+    return {
+        "key": "intent_accuracy",
+        "score": 1.0 if match else 0.0,
+        "comment": f"actual={actual!r} expected={expected!r}",
+    }
+
+
+def source_attribution(run, example) -> dict:
+    """
+    Assert len(sources_cited) > 0 when news_articles or filing_chunks are non-empty.
+    Score: 1.0 if sources_cited is populated when data is available, or if no data available.
+            0.0 if data was available but no sources were cited.
+    """
+    outputs = run.outputs or {}
+    news_articles = outputs.get("news_articles") or []
+    filing_chunks = outputs.get("filing_chunks") or []
+    sources_cited = outputs.get("sources_cited") or []
+
+    data_available = len(news_articles) > 0 or len(filing_chunks) > 0
+
+    if not data_available:
+        return {"key": "source_attribution", "score": 1.0, "comment": "No data available — N/A"}
+
+    score = 1.0 if len(sources_cited) > 0 else 0.0
+    return {
+        "key": "source_attribution",
+        "score": score,
+        "comment": f"{len(sources_cited)} sources cited, {len(news_articles)} news + {len(filing_chunks)} filing chunks available",
+    }

--- a/tests/evaluators/run_experiment.py
+++ b/tests/evaluators/run_experiment.py
@@ -1,0 +1,72 @@
+"""
+Run a LangSmith evaluation experiment against the stock-insight-agent-baseline dataset.
+
+Usage:
+    source .venv/bin/activate
+    PYTHONPATH=. python tests/evaluators/run_experiment.py
+
+This script:
+  1. Runs the LangGraph graph against all examples in the dataset
+  2. Scores each run with the 6 custom evaluators
+  3. Uploads results to LangSmith under the experiment name 'baseline-post-review'
+
+Compare 'baseline-post-review' against 'baseline-4d729529' in the LangSmith UI
+to see the before/after quality improvement.
+
+Requirements: GROQ_API_KEY and LANGSMITH_API_KEY must be set in .env
+"""
+
+import asyncio
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from langsmith import Client
+from agent.graph.workflow import app as graph
+from tests.evaluators.custom_evaluators import ALL_EVALUATORS
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+
+DATASET_NAME = "stock-insight-agent-baseline"
+EXPERIMENT_NAME = "baseline-post-review"
+
+
+def run_graph(inputs: dict) -> dict:
+    """
+    Synchronous wrapper around the async LangGraph graph.
+    LangSmith's client.evaluate() calls this for each dataset example.
+    """
+    state = {
+        "user_message": inputs.get("user_message", ""),
+        "user_config": inputs.get("user_config", {}),
+        "response_depth": inputs.get("response_depth", "quick"),
+        # Pass through any seeded context fields (ticker, dates) from dataset examples
+        **{k: v for k, v in inputs.items() if k in ("ticker", "company_name", "start_date", "end_date", "date_context")},
+    }
+    return asyncio.run(graph.ainvoke(state))
+
+
+if __name__ == "__main__":
+    client = Client()
+
+    print(f"Running experiment '{EXPERIMENT_NAME}' against dataset '{DATASET_NAME}'...")
+    print(f"Evaluators: {[fn.__name__ for fn in ALL_EVALUATORS]}")
+    print()
+
+    results = client.evaluate(
+        run_graph,
+        data=DATASET_NAME,
+        evaluators=ALL_EVALUATORS,
+        experiment_prefix=EXPERIMENT_NAME,
+        description=(
+            "Post-review baseline: Phase 1 bug fixes + Phase 2 improvements merged. "
+            "Compare against baseline-4d729529 for before/after quality delta."
+        ),
+        max_concurrency=1,   # sequential — avoids Groq rate limits
+    )
+
+    print(f"\nExperiment complete.")
+    print(f"View results at: https://smith.langchain.com")
+    print(f"Filter by experiment prefix: {EXPERIMENT_NAME}")

--- a/tests/test_date_parser_patterns.py
+++ b/tests/test_date_parser_patterns.py
@@ -1,0 +1,249 @@
+"""
+Exhaustive parametrized tests for date_parser.py.
+
+This file tests every Layer 1 pattern, Layer 2 earnings lookup, and
+Layer 3 LLM fallback (mocked). Any future date expression addition must
+have a test case here before the PR is merged.
+
+Why a separate file from test_date_parser.py?
+test_date_parser.py tests the node function end-to-end.
+This file tests each parsing layer in isolation, making it easy to
+identify exactly which layer a new pattern should live in.
+"""
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+
+from agent.graph.nodes.date_parser import (
+    parse_dates,
+    _parse_simple_range,
+    _parse_earnings_range,
+    _parse_with_llm,
+)
+
+BASE_STATE = {"user_message": "", "user_config": {}, "ticker": "NVDA"}
+TODAY = datetime.now()
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — simple relative ranges
+# ---------------------------------------------------------------------------
+
+class TestLayer1SimpleRange:
+
+    @pytest.mark.parametrize("n", [1, 7, 14, 30, 90])
+    def test_last_n_days(self, n):
+        result = _parse_simple_range(f"How did NVDA do the last {n} days?")
+        assert result is not None
+        start, end, ctx = result
+        expected_start = (TODAY - timedelta(days=n)).strftime("%Y-%m-%d")
+        assert start == expected_start
+        assert end == TODAY.strftime("%Y-%m-%d")
+
+    @pytest.mark.parametrize("n", [1, 2, 4, 12])
+    def test_last_n_weeks(self, n):
+        result = _parse_simple_range(f"last {n} weeks")
+        assert result is not None
+        start, end, ctx = result
+        expected_start = (TODAY - timedelta(weeks=n)).strftime("%Y-%m-%d")
+        assert start == expected_start
+
+    @pytest.mark.parametrize("n", [1, 3, 6, 12])
+    def test_last_n_months(self, n):
+        result = _parse_simple_range(f"past {n} months")
+        assert result is not None
+
+    def test_last_week(self):
+        result = _parse_simple_range("last week")
+        assert result is not None
+        start, end, ctx = result
+        expected = (TODAY - timedelta(weeks=1)).strftime("%Y-%m-%d")
+        assert start == expected
+
+    def test_last_month(self):
+        result = _parse_simple_range("last month")
+        assert result is not None
+
+    def test_last_quarter(self):
+        result = _parse_simple_range("last quarter")
+        assert result is not None
+        start, _, _ = result
+        expected = (TODAY - timedelta(days=90)).strftime("%Y-%m-%d")
+        assert start == expected
+
+    def test_last_year(self):
+        result = _parse_simple_range("last year")
+        assert result is not None
+
+    def test_this_week(self):
+        result = _parse_simple_range("this week")
+        assert result is not None
+        start, _, _ = result
+        monday = (TODAY - timedelta(days=TODAY.weekday())).strftime("%Y-%m-%d")
+        assert start == monday
+
+    def test_this_month(self):
+        result = _parse_simple_range("this month")
+        assert result is not None
+        start, _, _ = result
+        assert start == TODAY.replace(day=1).strftime("%Y-%m-%d")
+
+    def test_yesterday(self):
+        result = _parse_simple_range("yesterday")
+        assert result is not None
+        start, end, _ = result
+        expected = (TODAY - timedelta(days=1)).strftime("%Y-%m-%d")
+        assert start == expected
+        assert end == expected  # yesterday is a single-day range
+
+    @pytest.mark.parametrize("n", [1, 3, 6])
+    def test_n_months_ago(self, n):
+        result = _parse_simple_range(f"{n} months ago")
+        assert result is not None
+
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_n_weeks_ago(self, n):
+        result = _parse_simple_range(f"{n} weeks ago")
+        assert result is not None
+
+    @pytest.mark.parametrize("n", [1, 5, 10])
+    def test_n_days_ago(self, n):
+        result = _parse_simple_range(f"{n} days ago")
+        assert result is not None
+
+    # --- Calendar quarter patterns (Bug #1 category) ---
+
+    @pytest.mark.parametrize("quarter,year,expected_start,expected_end", [
+        (1, 2024, "2024-01-01", "2024-03-31"),
+        (2, 2024, "2024-04-01", "2024-06-30"),
+        (3, 2024, "2024-07-01", "2024-09-30"),
+        (4, 2024, "2024-10-01", "2024-12-31"),
+        (4, 2025, "2025-10-01", "2025-12-31"),  # The exact bug from production
+        (1, 2022, "2022-01-01", "2022-03-31"),
+    ])
+    def test_quarter_year(self, quarter, year, expected_start, expected_end):
+        """Q{N} YYYY must resolve via Layer 1, never reaching LLM."""
+        message = f"Q{quarter} {year}"
+        with patch("agent.graph.nodes.date_parser.llm_classifier") as mock_llm:
+            mock_llm.invoke.side_effect = AssertionError("Layer 3 LLM called unexpectedly")
+            result = _parse_simple_range(message)
+        assert result is not None, f"Layer 1 missed Q{quarter} {year}"
+        start, end, _ = result
+        assert start == expected_start, f"Q{quarter} {year}: start {start} != {expected_start}"
+        assert end == expected_end, f"Q{quarter} {year}: end {end} != {expected_end}"
+
+    @pytest.mark.parametrize("message,quarter,year", [
+        ("Q3 of 2022", 3, 2022),
+        ("Q1 of 2025", 1, 2025),
+    ])
+    def test_quarter_of_year(self, message, quarter, year):
+        """'Q{N} of YYYY' variant must also resolve via Layer 1."""
+        result = _parse_simple_range(message)
+        assert result is not None, f"Layer 1 missed: {message!r}"
+
+    def test_quarter_mid_sentence(self):
+        """Q pattern must match anywhere in a sentence, not just at start."""
+        message = "Tell me how Nvidia did Q4 2025. Show me a chart as well"
+        result = _parse_simple_range(message)
+        assert result is not None, "Q4 2025 not matched mid-sentence"
+        start, end, _ = result
+        assert start == "2025-10-01"
+        assert end == "2025-12-31"
+
+    def test_no_match_returns_none(self):
+        result = _parse_simple_range("What is the stock price?")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — earnings-relative lookup
+# ---------------------------------------------------------------------------
+
+class TestLayer2EarningsRange:
+
+    def test_earnings_keyword_required(self):
+        """Without 'earnings' keyword, Layer 2 must return None."""
+        result = _parse_earnings_range("Q2 2024 performance of NVDA", "NVDA")
+        assert result is None
+
+    def test_earnings_with_quarter_year(self):
+        """With 'earnings' keyword + Q{N} YYYY, Layer 2 must attempt yfinance lookup."""
+        mock_dt = datetime(2024, 5, 22)
+        with patch("agent.graph.nodes.date_parser._get_earnings_date", return_value=mock_dt):
+            result = _parse_earnings_range("Q2 2024 earnings", "NVDA")
+        assert result is not None
+        start, end, ctx = result
+        # 14 days before earnings, 7 days after
+        assert start == "2024-05-08"
+        assert end == "2024-05-29"
+        assert "Q2 2024 earnings" in ctx
+
+    def test_earnings_yfinance_miss_returns_none(self):
+        """If yfinance can't find the earnings date, Layer 2 returns None (fall through to LLM)."""
+        with patch("agent.graph.nodes.date_parser._get_earnings_date", return_value=None):
+            result = _parse_earnings_range("Q2 2024 earnings", "NVDA")
+        assert result is None
+
+    def test_no_ticker_returns_none(self):
+        result = _parse_earnings_range("Q2 2024 earnings", "")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — LLM fallback (mocked)
+# ---------------------------------------------------------------------------
+
+class TestLayer3LLMFallback:
+
+    def test_llm_called_for_complex_expression(self):
+        """Layer 3 LLM must be called for expressions Layer 1 and 2 can't handle."""
+        state = {**BASE_STATE, "user_message": "during the COVID crash"}
+        mock_response = MagicMock()
+        mock_response.content = '{"start_date": "2020-02-20", "end_date": "2020-03-23", "date_context": "COVID crash"}'
+
+        with patch("agent.graph.nodes.date_parser.llm_classifier") as mock_llm:
+            mock_llm.invoke.return_value = mock_response
+            result = parse_dates(state)
+
+        mock_llm.invoke.assert_called_once()
+        assert result["start_date"] == "2020-02-20"
+        assert result["end_date"] == "2020-03-23"
+        assert result["date_missing"] is False
+
+    def test_llm_returns_null_sets_date_missing(self):
+        """If LLM returns null dates, date_missing must be True."""
+        state = {**BASE_STATE, "user_message": "some completely ambiguous message"}
+        mock_response = MagicMock()
+        mock_response.content = '{"start_date": null, "end_date": null, "date_context": null}'
+
+        with patch("agent.graph.nodes.date_parser.llm_classifier") as mock_llm:
+            mock_llm.invoke.return_value = mock_response
+            result = parse_dates(state)
+
+        assert result["date_missing"] is True
+
+
+# ---------------------------------------------------------------------------
+# Node function — session context preservation
+# ---------------------------------------------------------------------------
+
+class TestSessionContext:
+
+    def test_session_context_preserved_when_no_date_in_message(self):
+        """If user sends a follow-up with no date, existing start/end must be preserved."""
+        state = {
+            **BASE_STATE,
+            "user_message": "What about the chart?",
+            "start_date": "2025-02-01",
+            "end_date": "2025-02-28",
+        }
+        with patch("agent.graph.nodes.date_parser.llm_classifier") as mock_llm:
+            mock_llm.invoke.return_value = MagicMock(
+                content='{"start_date": null, "end_date": null, "date_context": null}'
+            )
+            result = parse_dates(state)
+
+        assert result["date_missing"] is False
+        assert result["start_date"] == "2025-02-01"
+        assert result["end_date"] == "2025-02-28"

--- a/tests/test_integration_graph.py
+++ b/tests/test_integration_graph.py
@@ -1,0 +1,205 @@
+"""
+Integration tests for the LangGraph workflow.
+
+These tests run the compiled graph with real LLM calls to validate:
+- Inter-node state contracts (output of node N is in the format node N+1 expects)
+- Routing paths (all conditional edge branches)
+- Session context preservation
+- Parallel fan-out convergence
+
+External data APIs (yfinance, Reddit, EDGAR, NewsAPI) are mocked.
+LLM calls are REAL — this tests that intent/ticker/date nodes produce
+correct outputs for known inputs, not just that they call the LLM.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from agent.graph.workflow import app as graph
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _mock_yfinance_history():
+    """Minimal yfinance history DataFrame mock."""
+    import pandas as pd
+    data = {
+        "Open": [100.0, 101.0, 102.0],
+        "High": [105.0, 106.0, 107.0],
+        "Low": [98.0, 99.0, 100.0],
+        "Close": [103.0, 104.0, 105.0],
+        "Volume": [1_000_000, 1_100_000, 900_000],
+    }
+    idx = pd.date_range("2025-02-17", periods=3)
+    return pd.DataFrame(data, index=idx)
+
+
+def _mock_ticker(history_df):
+    mock = MagicMock()
+    mock.history.return_value = history_df
+    mock.info = {
+        "shortName": "NVIDIA Corporation",
+        "targetMeanPrice": 900.0,
+        "targetHighPrice": 1000.0,
+        "targetLowPrice": 800.0,
+        "numberOfAnalystOpinions": 40,
+    }
+    mock.earnings_dates = None
+    mock.options = ()
+    return mock
+
+
+def _rag_mocks():
+    """Context manager stack for patching all RAG/external dependencies."""
+    import contextlib
+
+    @contextlib.contextmanager
+    def _patch_all():
+        with patch("agent.graph.nodes.news_retriever._fetch_newsapi", return_value=None):
+            with patch("agent.graph.nodes.news_retriever._fetch_google_rss", return_value=None):
+                with patch("agent.graph.nodes.rag_retriever._get_collection") as mock_col:
+                    mock_col.return_value.count.return_value = 0
+                    mock_col.return_value.query.return_value = {
+                        "documents": [[]], "metadatas": [[]], "distances": [[]]
+                    }
+                    with patch("agent.graph.nodes.rag_retriever._get_cik", return_value=None):
+                        with patch(
+                            "agent.graph.nodes.reddit_sentiment.analyze_reddit_sentiment",
+                            return_value={
+                                "sentiment_summary": None,
+                                "sentiment_posts": None,
+                                "sentiment_error": "Reddit credentials not configured",
+                            },
+                        ):
+                            yield
+
+    return _patch_all()
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_full_pipeline_stock_analysis_nvda_last_month():
+    """
+    End-to-end: 'How did NVDA do last month?' must complete without errors.
+    Validates: intent=stock_analysis, ticker=NVDA, date range resolved,
+    price_data populated, response_text non-empty.
+    """
+    state = {
+        "user_message": "How did NVDA do last month?",
+        "user_config": {},
+        "response_depth": "quick",
+    }
+
+    hist = _mock_yfinance_history()
+    with patch("yfinance.Ticker", return_value=_mock_ticker(hist)):
+        with _rag_mocks():
+            final = await graph.ainvoke(state)
+
+    assert final.get("intent") == "stock_analysis", f"Expected stock_analysis, got {final.get('intent')}"
+    assert final.get("ticker") == "NVDA", f"Expected NVDA, got {final.get('ticker')}"
+    assert final.get("start_date"), "start_date must be set"
+    assert final.get("end_date"), "end_date must be set"
+    assert final.get("price_data") is not None, "price_data must not be None"
+    assert final.get("response_text"), "response_text must be non-empty"
+    assert final.get("synthesizer_error") is None, f"synthesizer_error: {final.get('synthesizer_error')}"
+
+
+@pytest.mark.asyncio
+async def test_date_q4_2025_resolves_correctly():
+    """
+    Inter-node contract: date_parser must produce correct Q4 2025 dates
+    (now via Layer 1 — no LLM needed), and those dates must flow
+    correctly into price_data fetch. The Bug #1 regression test.
+    """
+    state = {
+        "user_message": "Tell me how Nvidia did Q4 2025. Show me a chart as well",
+        "user_config": {},
+        "response_depth": "quick",
+    }
+
+    hist = _mock_yfinance_history()
+    with patch("yfinance.Ticker", return_value=_mock_ticker(hist)):
+        with _rag_mocks():
+            final = await graph.ainvoke(state)
+
+    assert final.get("start_date") == "2025-10-01", f"Bug #1 regression: start_date={final.get('start_date')}"
+    assert final.get("end_date") == "2025-12-31", f"Bug #1 regression: end_date={final.get('end_date')}"
+    assert final.get("chart_requested") is True, "chart_requested must be True"
+
+
+@pytest.mark.asyncio
+async def test_unknown_intent_routes_to_synthesizer_directly():
+    """
+    Routing: unknown intent must skip all data nodes and go to synthesize.
+    Validates that the synthesizer returns a clarification message.
+    """
+    state = {
+        "user_message": "What is the capital of France?",
+        "user_config": {},
+        "response_depth": "quick",
+    }
+
+    with patch("agent.graph.nodes.data_fetcher.fetch_price_data") as mock_fetch:
+        final = await graph.ainvoke(state)
+        mock_fetch.assert_not_called()
+
+    assert final.get("intent") == "unknown"
+    assert final.get("response_text"), "Synthesizer must produce a response for unknown intent"
+
+
+@pytest.mark.asyncio
+async def test_date_missing_skips_data_nodes():
+    """
+    Routing: when no date can be extracted, graph routes to synthesize,
+    skipping all data fetch nodes.
+    """
+    state = {
+        "user_message": "Tell me about NVDA",  # no date expression
+        "user_config": {},
+        "response_depth": "quick",
+    }
+
+    with patch("agent.graph.nodes.data_fetcher.fetch_price_data") as mock_fetch:
+        final = await graph.ainvoke(state)
+        if final.get("date_missing"):
+            mock_fetch.assert_not_called()
+
+    assert final.get("response_text"), "Must produce a response even when date is missing"
+
+
+@pytest.mark.asyncio
+async def test_session_context_preserved_across_turns():
+    """
+    Session context: a follow-up 'What about the chart?' must reuse ticker
+    and date from the previous turn's state fields.
+    """
+    state = {
+        "user_message": "What about the chart?",
+        "user_config": {},
+        "response_depth": "quick",
+        # Seeded from previous turn (as app.py does via last_context)
+        "ticker": "NVDA",
+        "company_name": "NVIDIA",
+        "start_date": "2025-02-19",
+        "end_date": "2025-03-19",
+        "date_context": "last month",
+    }
+
+    hist = _mock_yfinance_history()
+    with patch("yfinance.Ticker", return_value=_mock_ticker(hist)):
+        with _rag_mocks():
+            final = await graph.ainvoke(state)
+
+    assert final.get("ticker") == "NVDA", f"Ticker lost in session context: {final.get('ticker')}"
+    # start_date is either preserved from session context or re-resolved by the LLM —
+    # either outcome is valid. The important thing is it's non-empty.
+    assert final.get("start_date"), f"start_date must be non-empty, got: {final.get('start_date')}"
+    # chart_request produces chart_data; stock_analysis produces response_text.
+    # Either is a valid outcome for "What about the chart?" as a follow-up.
+    assert final.get("chart_data") or final.get("response_text"), \
+        "Must produce chart_data or response_text for follow-up"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,91 @@
+"""
+Smoke tests — real API calls, no mocks.
+
+These tests verify the full pipeline against live data.
+They are slow and require all API keys to be set.
+DO NOT run in CI. Run manually with:
+
+    PYTHONPATH=. pytest tests/test_smoke.py -v -s --no-header
+
+Each test asserts only on final state fields, not on response prose.
+"""
+
+import os
+import pytest
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Skip all smoke tests if GROQ_API_KEY is not set (required for LLM calls)
+pytestmark = pytest.mark.skipif(
+    not os.getenv("GROQ_API_KEY"),
+    reason="GROQ_API_KEY not set — smoke tests require live API keys"
+)
+
+from agent.graph.workflow import app as graph
+
+
+@pytest.mark.asyncio
+async def test_smoke_nvda_last_month():
+    """Full pipeline for NVDA last month — price, news, response."""
+    state = {"user_message": "How did NVDA do last month?", "user_config": {}, "response_depth": "quick"}
+    final = await graph.ainvoke(state)
+
+    assert final.get("ticker") == "NVDA"
+    assert final.get("start_date"), "start_date must be set"
+    assert final.get("price_data") is not None, "price_data must not be None"
+    assert final.get("response_text"), "response_text must be non-empty"
+    assert final.get("synthesizer_error") is None
+
+    print(f"\n[SMOKE] ticker={final['ticker']} start={final['start_date']} end={final['end_date']}")
+    print(f"[SMOKE] price_error={final.get('price_error')}")
+    print(f"[SMOKE] news articles={len(final.get('news_articles') or [])}")
+    print(f"[SMOKE] filing chunks={len(final.get('filing_chunks') or [])}")
+
+
+@pytest.mark.asyncio
+async def test_smoke_q4_2025_date_accuracy():
+    """Bug #1 regression at live API level: Q4 2025 must produce correct date range."""
+    state = {
+        "user_message": "Tell me how Nvidia did Q4 2025. Show me a chart as well",
+        "user_config": {},
+        "response_depth": "quick",
+    }
+    final = await graph.ainvoke(state)
+
+    assert final.get("start_date") == "2025-10-01", f"Q4 2025 start wrong: {final.get('start_date')}"
+    assert final.get("end_date") == "2025-12-31", f"Q4 2025 end wrong: {final.get('end_date')}"
+    assert final.get("chart_data") is not None, "chart_data must be set for chart request"
+
+    print(f"\n[SMOKE] start={final['start_date']} end={final['end_date']} chart={'yes' if final.get('chart_data') else 'no'}")
+
+
+@pytest.mark.asyncio
+async def test_smoke_deep_dive_has_all_sections():
+    """Deep dive response must contain all 5 markdown sections."""
+    state = {"user_message": "Deep dive on NVDA last month", "user_config": {}, "response_depth": "deep"}
+    final = await graph.ainvoke(state)
+
+    response = final.get("response_text") or ""
+    required_sections = [
+        "## Price Action",
+        "## News & Catalysts",
+        "## Market Sentiment",
+        "## SEC Filings",
+        "## Options Activity",
+    ]
+    for section in required_sections:
+        assert section in response, f"Deep dive missing section: {section!r}"
+
+    print(f"\n[SMOKE] deep dive response length={len(response)} chars")
+
+
+@pytest.mark.asyncio
+async def test_smoke_unknown_intent_produces_clarification():
+    """Non-stock query must produce a clarification message, not a crash."""
+    state = {"user_message": "What is the capital of France?", "user_config": {}, "response_depth": "quick"}
+    final = await graph.ainvoke(state)
+
+    assert final.get("intent") == "unknown"
+    assert final.get("response_text"), "Must produce a response for unknown intent"
+    assert final.get("synthesizer_error") is None


### PR DESCRIPTION
## Summary

- **Bug fix**: Q{N} YYYY patterns added to Layer 1 date parser — `Q4 2025` now resolves deterministically without LLM fallback; earnings-context guard prevents regression in Layer 2 window logic
- **Exhaustive date pattern tests** (`tests/test_date_parser_patterns.py`): 46 parametrized tests covering all Layer 1/2/3 paths + Bug #1 regression + session context preservation
- **Integration graph tests** (`tests/test_integration_graph.py`): 5 tests with real LLM + mocked APIs — inter-node contracts, routing paths (unknown intent, date_missing, chart_request), Bug #1 regression
- **Smoke tests** (`tests/test_smoke.py`): 4 live-API tests; skipped when `GROQ_API_KEY` absent; not for CI
- **LangSmith evaluators** (`tests/evaluators/custom_evaluators.py`): 6 custom evaluator functions ready to paste into LangSmith UI
- **LangSmith setup guide** (`docs/langsmith-setup.md`): copy/paste instructions for evaluator creation + `baseline-post-review` experiment
- **5 new dataset examples** added to `stock-insight-agent-baseline` via SDK

## Test plan

- [x] `pytest tests/ --ignore=tests/test_smoke.py` — 251 passed
- [x] `pytest tests/test_smoke.py -v -s` — 4 passed (live keys)
- [x] 5 LangSmith dataset examples added
- [x] `docs/langsmith-setup.md` documents all remaining UI steps