### PR TITLE
Phase 5: Quality improvements + Vertex AI migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,11 @@ Three distinct roles — never swap models between roles without updating this s
   - Nodes: Intent Classifier (1), Ticker Resolver (2), Date Parser (3), Reddit/Stocktwits sentiment batches (6)
   - Produces structured JSON; fast and cheap
 
-- **`llm_synthesizer`** — Google Gemini 2.5 Flash, temperature=0.3, max_output_tokens=4096, thinking_budget=1024
+- **`llm_synthesizer`** — Google Gemini 2.5 Pro (Vertex AI), temperature=0.3, max_output_tokens=4096, thinking_budget=2048
   - Node: Response Synthesizer (9)
   - Streaming enabled; Chainlit handles Gemini thinking-chunk format
-  - `thinking_budget=1024` gives the model an internal reasoning pass before the final response
+  - `thinking_budget=2048` gives the model an internal reasoning pass before the final response
+  - Auth via Application Default Credentials (ADC) — no API key required
 
 - **`llm_planner`** (Phase 5, new) — Groq `llama-3.1-8b-instant`, temperature=0, max_tokens=512
   - Node: Retrieval Planning Node
@@ -110,7 +111,11 @@ Available integrations — use these proactively when the task maps to their dom
 ```
 # Required
 GROQ_API_KEY=                    # llm_classifier + Node 6 sentiment batches
-GEMINI_API_KEY=                  # llm_synthesizer (Gemini 2.5 Flash) + RAG embeddings
+
+# Google Cloud (Vertex AI) — llm_synthesizer (Gemini 2.5 Pro) + RAG embeddings
+# Auth: Application Default Credentials — run `gcloud auth application-default login`
+GOOGLE_CLOUD_PROJECT=            # GCP project ID (e.g. stock-insight-agent)
+GOOGLE_CLOUD_LOCATION=           # Vertex AI region (e.g. us-central1)
 
 # Data — Node 4
 ALPHA_VANTAGE_API_KEY=           # Optional — fallback price data when yfinance fails

--- a/agent/graph/nodes/rag_retriever.py
+++ b/agent/graph/nodes/rag_retriever.py
@@ -20,7 +20,9 @@ Chunk IDs: {ticker}-{filing_type}-{period}-chunk-{N:03d}
   e.g. NVDA-10Q-2024Q2-chunk-014 — ChromaDB treats duplicate IDs as no-ops.
 
 External dependencies:
-  - GEMINI_API_KEY env var (required; node returns error if absent)
+  - GOOGLE_CLOUD_PROJECT env var (required; node returns error if absent)
+  - GOOGLE_CLOUD_LOCATION env var (default: us-central1)
+  - Auth: Application Default Credentials — run `gcloud auth application-default login`
   - CHROMA_PERSIST_DIR env var (default: data/vector_store)
   - SEC EDGAR public API (no auth; User-Agent header required)
 """
@@ -48,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 CHROMA_PERSIST_DIR = os.getenv("CHROMA_PERSIST_DIR", "data/vector_store")
 COLLECTION_NAME = "sec_filings_gemini_embedding_001"
-EMBEDDING_MODEL = "models/gemini-embedding-001"
+EMBEDDING_MODEL = "gemini-embedding-001"
 EDGAR_BASE = "https://data.sec.gov"
 EDGAR_SUBMISSIONS = "https://data.sec.gov/submissions/CIK{cik}.json"
 EDGAR_TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
@@ -147,7 +149,11 @@ def _chunk_text(text: str, ticker: str, filing_type: str, period: str) -> list[d
 # ---------------------------------------------------------------------------
 
 def _get_genai_client() -> genai.Client:
-    return genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+    return genai.Client(
+        vertexai=True,
+        project=os.getenv("GOOGLE_CLOUD_PROJECT"),
+        location=os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1"),
+    )
 
 
 def _embed_texts(texts: list[str]) -> list[list[float]]:
@@ -470,10 +476,10 @@ def retrieve_rag_context(state: AgentState) -> AgentState:
         logger.debug("retrieve_rag_context: no date range for %s, skipping", ticker)
         return {"filing_chunks": [], "filing_ingested": False, "filing_error": None}
 
-    gemini_api_key = os.getenv("GEMINI_API_KEY")
-    if not gemini_api_key:
-        logger.warning("retrieve_rag_context: GEMINI_API_KEY not set")
-        return {"filing_chunks": [], "filing_ingested": False, "filing_error": "GEMINI_API_KEY not configured"}
+    gcp_project = os.getenv("GOOGLE_CLOUD_PROJECT")
+    if not gcp_project:
+        logger.warning("retrieve_rag_context: GOOGLE_CLOUD_PROJECT not set")
+        return {"filing_chunks": [], "filing_ingested": False, "filing_error": "GOOGLE_CLOUD_PROJECT not configured"}
 
     try:
         collection = _get_collection()

--- a/docs/DecisionLog.md
+++ b/docs/DecisionLog.md
@@ -428,3 +428,24 @@ An intermediate step used Groq llama-3.3-70b-versatile as the synthesizer upgrad
 **Choice and Rationale:** LLM-driven planner. The planner adds one cheap, fast LLM call before the fan-out and can eliminate several seconds of parallel I/O when retrieval is unnecessary. The fallback guarantee (all nodes activate on failure) means the planner cannot make the system worse — worst case is pre-planner behaviour. Rule-based routing was rejected because intent classification alone is too coarse: both "how did NVDA do last week?" and "what did NVDA management say about margins in Q2 earnings?" classify as `stock_analysis`, but only the second warrants RAG retrieval.
 
 **Tradeoffs Accepted:** One additional LLM call per `stock_analysis` query (~100 ms on Groq free tier). New state fields: `retrieval_plan` (dict) and `planner_error` (str or None). Workflow topology change: `route_after_fetch_price` now routes to `plan_retrieval` instead of directly to the fan-out for all non-chart intents. The planner's decision is logged at INFO level for LangSmith trace inspection.
+
+---
+
+## Decision 21: Migrate Gemini to Vertex AI; Upgrade Synthesizer to Gemini 2.5 Pro
+
+**Date:** April 2026 **Status:** Accepted
+
+**Decision:** Route all Gemini usage (synthesizer + embeddings) through Google Cloud Vertex AI instead of the Google AI Studio API. Simultaneously upgrade the synthesizer model from Gemini 2.5 Flash to Gemini 2.5 Pro.
+
+**Context:** The project was using the Google AI Studio API (`GEMINI_API_KEY`) for both the Response Synthesizer (Node 9) and RAG embeddings (Node 7). GCP signup credits ($300) were available on the `stock-insight-agent` project but are scoped to GCP services — they do not apply to Google AI Studio billing. Routing through Vertex AI unlocks these credits and eliminates the cost constraint on model quality. Gemini 2.5 Pro is the most capable model in the Gemini family; upgrading from Flash is appropriate now that cost is no longer a constraint.
+
+**Options Considered:**
+
+- **Stay on AI Studio (status quo):** No setup changes. Credits remain unused. Free tier rate limits apply.
+- **Migrate to Vertex AI, keep Gemini 2.5 Flash:** Uses credits, same model quality.
+- **Migrate to Vertex AI, upgrade to Gemini 2.5 Pro:** Uses credits, materially better synthesis quality for analyst briefs.
+- **Switch synthesizer to Claude (Vertex AI Model Garden):** Also available via Vertex AI. Deferred — see planned experiment in project notes.
+
+**Choice and Rationale:** Vertex AI with Gemini 2.5 Pro. Both `langchain-google-genai` and `google-genai` support Vertex AI natively via a `vertexai=True` flag — no package swap required. Auth switches from API key to Application Default Credentials (ADC), which is the standard GCP auth pattern. The `thinking_budget` is increased from 1024 to 2048 tokens; Pro benefits more from deeper reasoning passes given its larger capacity. The embedding model (`gemini-embedding-001`) is unchanged — only the client initialization differs (drop `models/` prefix for Vertex AI model naming).
+
+**Tradeoffs Accepted:** `GEMINI_API_KEY` removed; replaced by `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION`. Local development now requires `gcloud auth application-default login`. CI/CD and production deployments will require a service account with Vertex AI permissions. `sentence-transformers` removed from requirements.txt — it was never imported in code; its presence was causing a spurious PyTorch version warning in the test runner.

--- a/llm/llm_setup.py
+++ b/llm/llm_setup.py
@@ -6,7 +6,8 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 load_dotenv()
 
 _groq_key = os.getenv("GROQ_API_KEY")
-_gemini_key = os.getenv("GEMINI_API_KEY")
+_gcp_project = os.getenv("GOOGLE_CLOUD_PROJECT")
+_gcp_location = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
 
 # Used by classifier/extractor nodes (Intent, Ticker, Date).
 # temperature=0 → deterministic JSON output; no creativity needed here.
@@ -20,18 +21,21 @@ llm_classifier = ChatGroq(
 )
 
 # Used by the Response Synthesizer (Node 9).
-# Gemini 2.5 Flash: reasoning model for narrative synthesis across multi-source data.
+# Gemini 2.5 Pro: most capable Gemini model; stronger reasoning for multi-source synthesis.
 # temperature=0.3 → slight variation for natural-sounding prose.
 # max_output_tokens=4096 → analyst briefs need room for substantive analysis.
-# thinking_budget=1024 → enables internal reasoning so the model connects data
-#   points (price action ↔ news ↔ catalysts) rather than just reciting them.
+# thinking_budget=2048 → doubled from Flash baseline; Pro benefits from deeper reasoning
+#   passes when connecting price action ↔ news ↔ catalysts ↔ SEC filings.
+# vertexai=True → routes through Vertex AI (ADC auth) instead of AI Studio API key.
 # streaming=True → enables token-by-token delivery via astream_events.
 llm_synthesizer = ChatGoogleGenerativeAI(
-    model="gemini-2.5-flash",
+    model="gemini-2.5-pro",
     temperature=0.3,
     max_output_tokens=4096,
-    thinking_budget=1024,
-    google_api_key=_gemini_key,
+    thinking_budget=2048,
+    vertexai=True,
+    project=_gcp_project,
+    location=_gcp_location,
     streaming=True,
 )
 

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -7,10 +7,13 @@
 
 /* ── Base ─────────────────────────────────────────────────────────────── */
 
+/* Chainlit's bundled CSS loads after this file and wins the cascade.
+   !important is required here — this is intentional theme overriding. */
+html,
 body {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-    background-color: #0f1117;
-    color: #e6edf3;
+    background-color: #0f1117 !important;
+    color: #e6edf3 !important;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif !important;
 }
 
 /* ── Message step containers ──────────────────────────────────────────── */
@@ -42,6 +45,18 @@ body {
 [data-testid="chat-input"]:focus-within {
     border-color: #00c896 !important;
     box-shadow: 0 0 0 3px rgba(0, 200, 150, 0.12) !important;
+}
+
+textarea,
+input,
+[data-testid="chat-input"] textarea,
+[data-testid="chat-input"] input {
+    color: #1a1a1a !important;
+}
+
+textarea::placeholder,
+input::placeholder {
+    color: #888888 !important;
 }
 
 /* ── Scrollbar ────────────────────────────────────────────────────────── */

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ requests~=2.32.4
 # Vector Store and Embeddings
 chromadb
 google-genai
-sentence-transformers
 
 # UI and Visualization
 chainlit

--- a/tests/test_rag_retriever.py
+++ b/tests/test_rag_retriever.py
@@ -75,14 +75,14 @@ def test_no_end_date_returns_empty():
     assert result["filing_chunks"] == []
 
 
-def test_missing_gemini_key_uses_fallback():
-    """When GEMINI_API_KEY is absent, the node returns early with a descriptive
+def test_missing_gcp_project_uses_fallback():
+    """When GOOGLE_CLOUD_PROJECT is absent, the node returns early with a descriptive
     filing_error rather than attempting to embed or query ChromaDB."""
-    env_without_key = {k: v for k, v in os.environ.items() if k != "GEMINI_API_KEY"}
+    env_without_key = {k: v for k, v in os.environ.items() if k != "GOOGLE_CLOUD_PROJECT"}
     with patch.dict(os.environ, env_without_key, clear=True):
         result = retrieve_rag_context(BASE_STATE)
     assert result["filing_chunks"] == []
-    assert result["filing_error"] == "GEMINI_API_KEY not configured"
+    assert result["filing_error"] == "GOOGLE_CLOUD_PROJECT not configured"
 
 
 # ---------------------------------------------------------------------------
@@ -92,7 +92,7 @@ def test_missing_gemini_key_uses_fallback():
 @patch("agent.graph.nodes.rag_retriever.genai")
 @patch("agent.graph.nodes.rag_retriever._get_collection")
 @patch("agent.graph.nodes.rag_retriever._embed_query")
-@patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"})
+@patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"})
 def test_cache_hit_returns_chunks_without_edgar(mock_embed_q, mock_get_col, mock_genai):
     mock_embed_q.return_value = [0.1] * 768
 
@@ -117,7 +117,7 @@ def test_cache_hit_returns_chunks_without_edgar(mock_embed_q, mock_get_col, mock
 @patch("agent.graph.nodes.rag_retriever.genai")
 @patch("agent.graph.nodes.rag_retriever._get_collection")
 @patch("agent.graph.nodes.rag_retriever._embed_query")
-@patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"})
+@patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"})
 def test_cache_hit_does_not_call_edgar(mock_embed_q, mock_get_col, mock_genai):
     """When cache has results, EDGAR should not be called."""
     mock_embed_q.return_value = [0.1] * 768
@@ -146,7 +146,7 @@ def test_cache_hit_does_not_call_edgar(mock_embed_q, mock_get_col, mock_genai):
 @patch("agent.graph.nodes.rag_retriever._get_cik")
 @patch("agent.graph.nodes.rag_retriever._discover_filings")
 @patch("agent.graph.nodes.rag_retriever._ingest_filing")
-@patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"})
+@patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"})
 def test_cache_miss_triggers_ingestion(
     mock_ingest, mock_discover, mock_cik, mock_embed_q, mock_get_col, mock_genai
 ):
@@ -185,7 +185,7 @@ def test_cache_miss_triggers_ingestion(
 @patch("agent.graph.nodes.rag_retriever._embed_query")
 @patch("agent.graph.nodes.rag_retriever._get_cik")
 @patch("agent.graph.nodes.rag_retriever._discover_filings")
-@patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"})
+@patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"})
 def test_ingest_sets_filing_ingested_true(
     mock_discover, mock_cik, mock_embed_q, mock_get_col, mock_genai
 ):
@@ -223,7 +223,7 @@ def test_ingest_sets_filing_ingested_true(
 @patch("agent.graph.nodes.rag_retriever._get_collection")
 @patch("agent.graph.nodes.rag_retriever._embed_query")
 @patch("agent.graph.nodes.rag_retriever._get_cik")
-@patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"})
+@patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"})
 def test_cik_not_found_returns_empty(mock_cik, mock_embed_q, mock_get_col, mock_genai):
     mock_embed_q.return_value = [0.1] * 768
     mock_cik.return_value = None
@@ -243,7 +243,7 @@ def test_cik_not_found_returns_empty(mock_cik, mock_embed_q, mock_get_col, mock_
 @patch("agent.graph.nodes.rag_retriever._embed_query")
 @patch("agent.graph.nodes.rag_retriever._get_cik")
 @patch("agent.graph.nodes.rag_retriever._discover_filings")
-@patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"})
+@patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"})
 def test_no_filings_in_range_returns_empty(
     mock_discover, mock_cik, mock_embed_q, mock_get_col, mock_genai
 ):
@@ -263,7 +263,7 @@ def test_no_filings_in_range_returns_empty(
 
 @patch("agent.graph.nodes.rag_retriever.genai")
 @patch("agent.graph.nodes.rag_retriever._get_collection")
-@patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"})
+@patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"})
 def test_exception_sets_filing_error(mock_get_col, mock_genai):
     """An unhandled exception inside the node should set filing_error."""
     mock_get_col.side_effect = RuntimeError("disk full")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -7,7 +7,7 @@ DO NOT run in CI. Run manually before any deployment:
 
     pytest tests/test_smoke.py -m smoke -v -s
 
-To run: ensure GROQ_API_KEY, GEMINI_API_KEY, FINNHUB_API_KEY are set in
+To run: ensure GROQ_API_KEY, GOOGLE_CLOUD_PROJECT, FINNHUB_API_KEY are set in
 your .env file. Tests are excluded from the standard suite (no CI credentials).
 """
 
@@ -79,8 +79,9 @@ async def test_smoke_analyst_brief_has_all_sections():
     # Minimum length — a real analyst note is at least 300 chars
     assert len(response) >= 300, f"Response too short: {len(response)} chars"
 
-    # Must mention the ticker or company name
-    assert "NVDA" in response or "NVIDIA" in response, "Response must reference the company"
+    # Must mention the ticker or company name (model may use any capitalisation)
+    assert any(name in response for name in ("NVDA", "NVIDIA", "Nvidia", "nvidia")), \
+        "Response must reference the company"
 
     # Must contain at least one inline citation if news was retrieved
     news_articles = final.get("news_articles") or []


### PR DESCRIPTION
## Summary

- **Phase 5 node upgrades:** Node 5 (news), Node 6 (sentiment), Node 9 (synthesizer prompt redesign), Node 3 (date parser), and new Retrieval Planner node — all upgraded with tests and LangSmith eval runs
- **Vertex AI migration:** Moved Gemini synthesizer and RAG embeddings from AI Studio API key auth to Vertex AI via Application Default Credentials; upgraded synthesizer from Gemini 2.5 Flash → Gemini 2.5 Pro (thinking_budget 1024→2048)
- **Cleanup:** Removed unused `sentence-transformers` dependency (was causing spurious PyTorch warnings); ADR-21 added to DecisionLog

## Test plan

- [x] 347 unit tests pass
- [x] 4/4 smoke tests pass against live Vertex AI endpoints (synthesizer + embeddings)
- [x] LangSmith experiments run for all Phase 5 node changes